### PR TITLE
Adding logic for azure portal and service principal

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -1,11 +1,29 @@
 #!/bin/bash -e
 
-if [[ ! -e ~/.azure ]]; then
+message() {
+  if [[ $auth -eq -1   ]]; then
+    echo "You token/password in ~/.azure/azure-build-key.txt is not right"
+  fi
   echo "No credentials present for the Azure CLI"
-  exit 1
-fi
+  echo "You can log in the azure portal and then run this again or add the password for the service principal in the ~/.azure/azure-build-key.txt file "
+  echo "You can find the service principal password in 1password in infrastructure under the Azure 'service-principal Cloud-Image-Build' name"
+}
 
-az login --service-principal -u 5ec337b0-2f46-4ef1-a336-41782a78dacf -p $(cat ~/.azure/azure-build-key.txt) --tenant 303c34b0-e6cc-4ed4-bc66-99f6ae15f78d
+auth=-1
+if [[ ! -e ~/.azure ]]; then
+  echo "Trying to connect to azure using token from Browser login"
+  tl=$(az storage blob show -c public -n nsolid-quick-start.json --account-name nodesourcearmtemplates > /dev/null 2>&1 ; echo $?)
+else
+  echo "Trying to connect to azure using service principal"
+  auth=$(az login --service-principal -u 5ec337b0-2f46-4ef1-a336-41782a78dacf -p $(cat ~/.azure/azure-build-key.txt) --tenant 303c34b0-e6cc-4ed4-bc66-99f6ae15f78d > /dev/null 2>&1; echo $?)
+  tl=$(az storage blob show -c public -n nsolid-quick-start.json --account-name nodesourcearmtemplates > /dev/null 2>&1 ; echo $?)
+fi
+if [[ $tl -gt 0   ]]; then
+   message
+   exit 1
+else 
+   echo "Processing blobs"   
+fi   
 az storage blob upload --container-name public --name nsolid-quick-start.json --file templates/nsolid-quick-start.json --account-name nodesourcearmtemplates
 az storage blob upload --container-name public --name nsolid-console-only.json --file templates/nsolid-console-only.json --account-name nodesourcearmtemplates
 az storage blob upload --container-name public --name nsolid-runtime-only.json --file templates/nsolid-runtime-only.json --account-name nodesourcearmtemplates


### PR DESCRIPTION
WDUARTE:
https://github.com/nodesource/infrastructure/issues/55
- Password for service principal was missed
- Create a password for Service principal in 1password using 'Azure service-principal Cloud-Image-Build'
- Modify the upload.sh script to add logic to use azure portal web browser login and service principal 